### PR TITLE
Use our own installer (will extract later)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Benchmark Regression
+# Benchmark Regression [![NPM version](https://img.shields.io/npm/v/@clevernature/benchmark-regression.svg?style=flat)](https://www.npmjs.com/package/@clevernature/benchmark-api) [![Linux Build Status](https://img.shields.io/travis/nowells/benchmark-regression.svg?style=flat&label=Travis)](https://travis-ci.org/nowells/benchmark-regression)
 
 Generates performance regression tests using [benchmarkjs](https://benchmarkjs.com/).
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "eslint": "^5.6.0",
-    "prom-client": "^11.1.3"
+    "prom-client": "11.1.3"
   },
   "homepage": "https://github.com/nowells/benchmark-regression",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "cli-table": "^0.3.1",
     "libnpm": "^1.0.0",
     "lodash": "^4.17.11",
-    "lodash.frompairs": "^4.0.1",
     "npm": "^6.4.1",
     "tempy": "^0.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevernature/benchmark-regression",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Generates performance regression tests using benchmarkjs.",
   "main": "dist/index.js",
   "scripts": {
@@ -25,7 +25,8 @@
     "libnpm": "^1.0.0",
     "lodash": "^4.17.11",
     "npm": "^6.4.1",
-    "tempy": "^0.2.1"
+    "tempy": "^0.2.1",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,18 @@
     "benchmark": "^2.1.4",
     "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
+    "libnpm": "^1.0.0",
     "lodash": "^4.17.11",
-    "npm-install-tmp": "^0.1.5"
+    "lodash.frompairs": "^4.0.1",
+    "npm": "^6.4.1",
+    "tempy": "^0.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
-    "eslint": "^5.6.0"
+    "eslint": "^5.6.0",
+    "prom-client": "^11.1.3"
   },
   "homepage": "https://github.com/nowells/benchmark-regression",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevernature/benchmark-regression",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "Generates performance regression tests using benchmarkjs.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const benchmark = require('benchmark');
 const chalk = require('chalk');
-const { use } = require('npm-install-tmp');
+const npmInstallPackage = require('./npm-install-package');
 const reportResults = require('./report');
 
 module.exports = createRegressionBenchmark;
@@ -136,7 +136,10 @@ function createRegressionBenchmark(baseModule, comparisonModules = []) {
 async function installTestModules(testModules) {
     for (const testModule of testModules) {
         if (typeof testModule.module === 'string') {
-            testModule.module = await use(testModule.module);
+            const {id, module} = await npmInstallPackage(testModule.module);
+
+            testModule.module = module;
+            testModule.id = id;
         }
     }
 }

--- a/src/npm-install-package.js
+++ b/src/npm-install-package.js
@@ -1,0 +1,25 @@
+const npm = require('npm');
+const libnpm = require('libnpm');
+const tempy = require('tempy');
+const _ = require('lodash');
+const {promisify} = require('util');
+
+module.exports = installNpmPackage;
+
+async function installNpmPackage(spec) {
+    const prefix = tempy.directory();
+    const manifest = await libnpm.manifest(spec);
+
+    await promisify(npm.load)({loglevel: 'silent', progress: false});
+    const modulePaths = _.fromPairs(await promisify(npm.commands.install)(prefix, [spec]));
+    const requestedModule = modulePaths[manifest._id];
+
+    if (!requestedModule) {
+        throw new Error(`Could not resolve module for ${spec}`);
+    }
+
+    return {
+        id: manifest._id,
+        module: require(requestedModule)
+    }
+}

--- a/src/npm-install-package.js
+++ b/src/npm-install-package.js
@@ -2,7 +2,7 @@ const npm = require('npm');
 const libnpm = require('libnpm');
 const tempy = require('tempy');
 const _ = require('lodash');
-const {promisify} = require('util');
+const promisify = require('util.promisify');
 
 module.exports = installNpmPackage;
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const createRegressionBenchmark = require('..');
 const benchmarks = createRegressionBenchmark(
     require('prom-client'),
     [
-        'prom-client@latest',
+        'prom-client@11.1.2',
         'prom-client@11.1.1'
     ]
 );

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,13 @@
 
 const createRegressionBenchmark = require('..');
 
-const benchmarks = createRegressionBenchmark({name: 'latest', module: 'prom-client'}, ['prom-client@11.1.2', 'prom-client@11.1.1']);
+const benchmarks = createRegressionBenchmark(
+    require('prom-client'),
+    [
+        'prom-client@latest',
+        'prom-client@11.1.1'
+    ]
+);
 
 benchmarks.suite('registry', (suite) => {
     suite.add(


### PR DESCRIPTION
This will allow us to accept any npm spec to install. The previous package failed on non `x@y` style specs.