### PR TITLE
Support for asynchronous functions, and skipping individual runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ benchmarks.add(
     { setup }
 );
 
+benchmarks.add(
+    'asynchronous',
+    async (client, { histogram }) => {
+        const result = await lookup();
+        return result.name;
+    },
+    { setup }
+);
+
 benchmarks.run().catch(err => {
     console.error(err.stack);
     process.exit(1);

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ benchmarks.add(
     { setup }
 );
 
+
+benchmarks.add(
+    'skippable',
+    (client, { histogram }) => histogram.observe(1, { a: 1, b: 1 }),
+    { 
+        setup,
+        start: (event) => (event.target.name !== 'prom-client@10.1.3') // function not supported or broken in this version
+    }
+);
+
+
+
 benchmarks.run().catch(err => {
     console.error(err.stack);
     process.exit(1);

--- a/src/index.js
+++ b/src/index.js
@@ -28,14 +28,13 @@ function createRegressionBenchmark(baseModule, comparisonModules = []) {
             const bucket = buckets[bucketName];
 
             for (const benchmarkName of Object.keys(bucket)) {
-                const { fn, opts: { setup, teardown } } = bucket[benchmarkName];
+                const { fn, opts: { setup, teardown, start = undefined } } = bucket[benchmarkName];
 
                 const fastest = { time: -Infinity };
                 const slowest = { time: +Infinity };
 
                 for (const testModule of testModules) {
                     const name = `${bucketName} ➭ ${benchmarkName} ➭ ${testModule.name}`;
-
                     let ctx;
 
                     const result = await new Promise(async (resolve, reject) => {
@@ -86,6 +85,19 @@ function createRegressionBenchmark(baseModule, comparisonModules = []) {
                                 });
                             }
                         });
+
+
+                        if (start !== undefined) {
+                            // fake a start() call early
+                            bench.on('start', start);
+                            const cancelled = (bench.emit('start') === false);
+                            bench.off('start', start);
+
+                            if (cancelled) {
+                                bench.emit('complete');
+                                return;
+                            }
+                        }
 
                         ctx = await Promise.resolve(setup(testModule.module));
                         bench.run();

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ function createRegressionBenchmark(baseModule, comparisonModules = []) {
         for (const bucketName of Object.keys(buckets)) {
             const bucket = buckets[bucketName];
 
-
             for (const benchmarkName of Object.keys(bucket)) {
                 const { fn, opts: { setup, teardown } } = bucket[benchmarkName];
 
@@ -36,9 +35,21 @@ function createRegressionBenchmark(baseModule, comparisonModules = []) {
 
                 for (const testModule of testModules) {
                     const name = `${bucketName} ➭ ${benchmarkName} ➭ ${testModule.name}`;
-                    const ctx = await Promise.resolve(setup(testModule.module));
-                    const result = await new Promise((resolve, reject) => {
-                        const bench = new benchmark.Benchmark(name, () => fn(testModule.module, ctx));
+
+                    let ctx;
+
+                    const result = await new Promise(async (resolve, reject) => {
+                        const bench = new benchmark.Benchmark({
+                            name,
+                            defer: true,
+                            fn: async (done) => {
+                                try {
+                                    done.resolve(await fn(testModule.module, ctx));
+                                } catch (err) {
+                                    done.resolve(err);
+                                }
+                            }
+                        });
 
                         bench.on('complete', (event) => {
                             if (event.target.error) {
@@ -76,6 +87,7 @@ function createRegressionBenchmark(baseModule, comparisonModules = []) {
                             }
                         });
 
+                        ctx = await Promise.resolve(setup(testModule.module));
                         bench.run();
                     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -54,6 +54,19 @@ selftest.suite('async support', (suite) => {
         },
         { setup: asyncSetup },
     );
+
+    suite.add(
+        'start callback',
+        () => {
+            assert.fail('run should have been skipped');
+        },
+        {
+            setup: () => assert.fail('Setup should have been skipped'),
+            start: (event) => {
+                return (event.target.name !== 'async support ➭ start callback ➭ current');
+            }
+        },
+    );
 });
 
 benchmarks.run()

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const createRegressionBenchmark = require('..');
 
 const benchmarks = createRegressionBenchmark(
@@ -29,10 +30,38 @@ benchmarks.add(
     { setup }
 );
 
-benchmarks.run().catch(err => {
-    console.error(err.stack);
-    process.exit(1);
+const selftest = createRegressionBenchmark(
+    {}, []
+);
+
+selftest.suite('async support', (suite) => {
+    suite.add(
+        'async setup',
+        (client, { completed }) => assert(completed),
+        { setup: asyncSetup },
+    );
+
+    suite.add(
+        'async fn',
+        (client, ctx) => {
+            assert(ctx.running !== true);
+            ctx.running = true;
+
+            return new Promise(resolve => setTimeout(() => {
+                ctx.running = false;
+                resolve();
+            }, 100));
+        },
+        { setup: asyncSetup },
+    );
 });
+
+benchmarks.run()
+    .then(() => selftest.run())
+    .catch(err => {
+        console.error(err.stack);
+        process.exit(1);
+    });
 
 function setup(client) {
     const registry = new client.Registry();
@@ -47,4 +76,10 @@ function setup(client) {
     histogram.observe(1, { a: 1, b: 1 });
 
     return {registry, histogram};
+}
+
+async function asyncSetup() {
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    return { completed: {} };
 }


### PR DESCRIPTION
These changes came about as a result of trying and failing to write benchmarks  for parts of prom-client that did not have coverage.

Getting async to work was tricky. Getting benchmark-regression to successfully run in a child process was a slog. The setup
function cannot decide to run only a particular version because it doesn't have any access to that information due to how setup() was implemented outside the normal benchmark.js lifecycle (presumably to support async setup and teardown functions).

This change makes it work well enough to do what I wanted.

In writing it I realized that it would also be useful for anyone writing a benchmark for a function that is missing or broken in one of the versions they are testing. Being able to skip one but keep the others seems useful to me.